### PR TITLE
Typing fixes

### DIFF
--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -8,8 +8,9 @@ from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.log import cli_info, cli_warning
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag, IP_networkT
+from mreg_cli.types import Flag
 from mreg_cli.utilities.api import delete, get, get_list, patch, post
+from mreg_cli.utilities.network import network_is_supernet
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
 from mreg_cli.utilities.validators import is_valid_network
 
@@ -44,14 +45,6 @@ def network_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, range)
     """
-
-    # Replace with a.supernet_of(b) when python 3.7 is required
-    def _supernet_of(a: IP_networkT, b: IP_networkT) -> bool:
-        """Return True if a is a supernet of b."""
-        return bool(
-            a.network_address <= b.network_address and a.broadcast_address >= b.broadcast_address
-        )
-
     params = {
         "ordering": "range,group",
     }
@@ -65,9 +58,9 @@ def network_list(args: argparse.Namespace) -> None:
         argnetwork = ipaddress.ip_network(args.range)
         for i in permissions:
             permnet = ipaddress.ip_network(i["range"])
-            if argnetwork.version == permnet.version and _supernet_of(
-                argnetwork, ipaddress.ip_network(i["range"])
-            ):
+            if permnet.version != argnetwork.version:
+                continue  # no warning if the networks are not comparable
+            if network_is_supernet(argnetwork, permnet):  # type: ignore # guaranteed to be the same version
                 data.append(i)
     else:
         data = permissions

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -18,7 +18,9 @@ import configparser
 import logging
 import os
 import sys
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, overload
+
+from mreg_cli.types import DefaultType
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +88,17 @@ class MregCliConfig:
             if key.startswith(env_prefix)
         }
 
-    def get(self, key: str, default: str = None) -> Optional[str]:
+    @overload
+    def get(self, key: str) -> Optional[str]:
+        ...
+
+    @overload
+    def get(self, key: str, default: DefaultType = ...) -> Union[str, DefaultType]:
+        ...
+
+    def get(
+        self, key: str, default: Optional[DefaultType] = None
+    ) -> Optional[Union[str, DefaultType]]:
         """Get a configuration value with priority: cmdline, env, file.
 
         :param str key: Configuration key.

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -58,17 +58,20 @@ class MregCliConfig:
     """
 
     _instance = None
+    _config_cmd: Dict[str, str]
+    _config_file: Dict[str, str]
+    _config_env: Dict[str, str]
 
-    def __new__(cls):
+    def __new__(cls) -> "MregCliConfig":
         """Create a new instance of the configuration class.
 
         This ensures that only one instance of the configuration class is created.
         """
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance._config_file: Dict[str, str] = {}
-            cls._instance._config_env: Dict[str, str] = cls._load_env_config()
-            cls._instance._config_cmd: Dict[str, str] = {}
+            cls._instance._config_file = {}
+            cls._instance._config_env = cls._load_env_config()
+            cls._instance._config_cmd = {}
             cls._instance.get_config()
 
         return cls._instance

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -10,7 +10,7 @@ import datetime
 import json
 import os
 import re
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union, overload
 from urllib.parse import urlencode, urlparse
 
 import requests
@@ -18,9 +18,22 @@ import requests
 from mreg_cli.exceptions import CliError
 from mreg_cli.types import RecordingEntry, TimeInfo
 
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
-# These functions are for generic output usage, but can't be in util.py
-# because we would get a circular import.
+
+@overload
+def find_char_outside_quotes(line: str, target_char: str, return_position: "Literal[True]") -> int:
+    ...
+
+
+@overload
+def find_char_outside_quotes(
+    line: str, target_char: str, return_position: "Literal[False]"
+) -> str:
+    ...
+
+
 def find_char_outside_quotes(
     line: str, target_char: str, return_position: bool = False
 ) -> Union[str, int]:
@@ -57,8 +70,7 @@ def remove_comments(line: str) -> str:
     :param line: The line of text to process.
     :return: The line with comments removed.
     """
-    # Yes, this will always be a string, but linters fail to understand that.
-    return cast(str, find_char_outside_quotes(line, "#", False)).rstrip(" ")
+    return find_char_outside_quotes(line, "#", False).rstrip(" ")
 
 
 def remove_dict_key_recursive(obj: object, key: str) -> None:
@@ -260,7 +272,12 @@ class OutputManager:
         self._recorded_data.append(self.recording_entry())
 
     def recording_request(
-        self, method: str, url: str, params: str, data: Dict[str, Any], result: requests.Response
+        self,
+        method: str,
+        url: str,
+        params: Dict[str, Any],
+        data: Dict[str, Any],
+        result: requests.Response,
     ) -> None:
         """Record a request, if recording is active."""
         if not self.recording_active():

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -35,7 +35,7 @@ if sys.version_info >= (3, 8):
         warning: List[str]
         error: List[str]
         output: List[str]
-        api_requests: List[str]
+        api_requests: List[Dict[str, Any]]
         time: Optional[TimeInfo]
 
 else:

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -90,6 +90,11 @@ class Command(NamedTuple):
     flags: Optional[List[Flag]] = None
 
 
+# Config
+DefaultType = TypeVar("DefaultType")
+DefaultNotSet = object()
+
+
 if TYPE_CHECKING:
     from typing import Any
 

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -62,7 +62,7 @@ class Flag:
         nargs: Optional["NargsType"] = None,
         default: Any = None,
         flag_type: Any = None,
-        choices: List[str] = None,
+        choices: Optional[List[str]] = None,
         required: bool = False,
         metavar: Optional[str] = None,
         action: Optional[str] = None,

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -92,8 +92,6 @@ class Command(NamedTuple):
 
 # Config
 DefaultType = TypeVar("DefaultType")
-DefaultNotSet = object()
-
 
 if TYPE_CHECKING:
     from typing import Any

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union, cast, overload
+from urllib.parse import urljoin
 
 import requests
 
@@ -71,7 +72,7 @@ def login1(user: str, url: str) -> None:
     # Find a better URL.. but so far so good
     try:
         ret = session.get(
-            requests.compat.urljoin(MregCliConfig().get("url"), "/api/v1/hosts/"),
+            urljoin(MregCliConfig().get("url"), "/api/v1/hosts/"),
             params={"page_size": 1},
             timeout=5,
         )
@@ -95,7 +96,7 @@ def login(user: str, url: str) -> None:
 
 def logout() -> None:
     """Logout from MREG."""
-    path = requests.compat.urljoin(MregCliConfig().get("url"), "/api/token-logout/")
+    path = urljoin(MregCliConfig().get("url"), "/api/token-logout/")
     # Try to logout, and ignore errors
     try:
         session.post(path)
@@ -114,7 +115,7 @@ def update_token() -> None:
 
 def _update_token(username: Optional[str], password: str) -> None:
     """Perform the actual token update."""
-    tokenurl = requests.compat.urljoin(MregCliConfig().get("url"), "/api/token-auth/")
+    tokenurl = urljoin(MregCliConfig().get("url"), "/api/token-auth/")
     try:
         result = requests.post(tokenurl, {"username": username, "password": password})
     except requests.exceptions.SSLError as e:
@@ -168,7 +169,7 @@ def _request_wrapper(
     """Wrap request calls to MREG for logging and token management."""
     if params is None:
         params = {}
-    url = requests.compat.urljoin(MregCliConfig().get("url"), path)
+    url = urljoin(MregCliConfig().get("url"), path)
 
     if use_json:
         result = getattr(session, operation_type)(url, json=params, timeout=HTTP_TIMEOUT)

--- a/mreg_cli/utilities/history.py
+++ b/mreg_cli/utilities/history.py
@@ -22,8 +22,7 @@ def get_history_items(name: str, resource: str, data_relation: str = None) -> Li
     if len(ret) == 0:
         cli_warning(f"No history found for {name}")
     # Get all model ids, a group gets a new one when deleted and created again
-    model_ids = {str(i["model_id"]) for i in ret}
-    model_ids = ",".join(model_ids)
+    model_ids = ",".join({str(i["model_id"]) for i in ret})
     params = {
         "resource": resource,
         "model_id__in": model_ids,

--- a/mreg_cli/utilities/history.py
+++ b/mreg_cli/utilities/history.py
@@ -1,7 +1,7 @@
 """History log related functions."""
 
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dateutil.parser import parse
 
@@ -10,7 +10,9 @@ from mreg_cli.outputmanager import OutputManager
 from mreg_cli.utilities.api import get_list
 
 
-def get_history_items(name: str, resource: str, data_relation: str = None) -> List[Dict[str, Any]]:
+def get_history_items(
+    name: str, resource: str, data_relation: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """Get history items for a given name and resource."""
     # First check if any model id with the name exists
     path = "/api/v1/history/"
@@ -37,7 +39,7 @@ def get_history_items(name: str, resource: str, data_relation: str = None) -> Li
     return ret
 
 
-def format_history_items(ownname: str, items: Dict[str, Any]) -> None:
+def format_history_items(ownname: str, items: List[Dict[str, Any]]) -> None:
     """Format history items for output."""
 
     def _remove_unneded_keys(data: Dict[str, Any]):

--- a/mreg_cli/utilities/network.py
+++ b/mreg_cli/utilities/network.py
@@ -5,14 +5,12 @@ And this rule is promptly broken by importing from mreg_cli.outputmanager...
 """
 
 import ipaddress
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List
-
-if TYPE_CHECKING:
-    pass
-
+import sys
 import urllib.parse
+from typing import Any, Dict, Iterable, List
 
 from mreg_cli.log import cli_warning
+from mreg_cli.types import IP_networkT
 from mreg_cli.utilities.api import get
 from mreg_cli.utilities.validators import is_valid_ip, is_valid_network
 
@@ -102,3 +100,13 @@ def get_network_reserved_ips(ip_range: str) -> List[str]:
     """Return the first unused address on a network, if any."""
     path = f"/api/v1/networks/{urllib.parse.quote(ip_range)}/reserved_list"
     return get(path).json()
+
+
+def network_is_supernet(a: IP_networkT, b: IP_networkT) -> bool:
+    """Return True if a is a supernet of b."""
+    if sys.version_info >= (3, 7):
+        return a.supernet_of(b)
+    else:
+        return (
+            a.network_address <= b.network_address and a.broadcast_address >= b.broadcast_address
+        )


### PR DESCRIPTION
Mostly type annotation fixes. Most notably, methods that have a return type of `Union[T1, T2]` are given overloaded definitions to define when each return type can be expected. 

Has one semantic change , which is extracting `_supernet_of()` from `network_list()` and adding it to `utilities.network` under the name `network_is_supernet()`. This allows us to write unit tests for the functionality, but seeing as we don't have unit tests in place, this will have to be done in a future PR. Unit tests for `network_is_supernet()` can be found here: https://gist.github.com/pederhan/9bb1f2344ca55aa9705515fe3ffd05ed

