### PR TITLE
Allow oneshot commands from the terminal.

### DIFF
--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -111,6 +111,10 @@ def main():
         metavar="SOURCE",
     )
 
+    output_args.add_argument(
+        "command", metavar="command", nargs="*", help="Oneshot command to issue to the cli."
+    )
+
     args = parser.parse_args()
     setup_logging(args.verbosity)
     logger.debug(f"args: {args}")
@@ -169,6 +173,16 @@ def main():
         for command in source([conf["source"]], "verbosity" in conf, False):
             cli.process_command_line(command)
         return
+
+    # Check if we got a oneshot command. If so, execute it and exit.
+    if args.command:
+        cmd = " ".join(args.command)
+        try:
+            cli.process_command_line(cmd)
+        except ValueError as e:
+            print(e)
+
+        raise SystemExit() from None
 
     # The app runs in an infinite loop and is expected to exit using sys.exit()
     while True:


### PR DESCRIPTION
This patch allows the use of mreg-cli without interaction, ala:

`mreg-cli host info foo`

This will then feed the command `host info foo` to the cli and then exit.